### PR TITLE
fix: use from_xyzw

### DIFF
--- a/car/src/esp.rs
+++ b/car/src/esp.rs
@@ -17,12 +17,12 @@ pub fn aero_system(mut car_query: Query<(&Velocity, &Transform, &mut ExternalFor
 }
 
 // Quat::from_axis_angle(-Vec3::Y, PI / 2.) = Quat(-0.0, -0.70710677, -0.0, 0.70710677);
-const WHEEL_RAY_END_QUAT: Quat = Quat {
-    x: -0.0,
-    y: -0.70710677,
-    z: -0.0,
-    w: 0.70710677,
-};
+const WHEEL_RAY_END_QUAT: Quat = Quat::from_xyzw(
+    -0.0,
+    -0.70710677,
+    -0.0,
+    0.70710677,
+);
 const WHEEL_RAY_SHIFT: Vec3 = Vec3 {
     x: 0.,
     y: 0.5,


### PR DESCRIPTION
Fix an error

```
   Compiling bevy_garage_car v0.1.0 (/Users/katopz/git/katopz/bevy_garage/car)
error[E0560]: struct `bevy::prelude::Quat` has no field named `x`
  --> car/src/esp.rs:21:5
   |
21 |     x: -0.0,
   |     ^ field does not exist
   |
  ::: /Users/katopz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/glam-0.24.1/src/f32/sse2/quat.rs:46:12
   |
46 | pub struct Quat(pub(crate) __m128);
   |            ---- `bevy::prelude::Quat` defined here
   |
help: `bevy::prelude::Quat` is a tuple struct, use the appropriate syntax
   |
20 | const WHEEL_RAY_END_QUAT: Quat = bevy::prelude::Quat(/* fields */);
```